### PR TITLE
feat: Automatically allow all aliases to call the lambda

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 [Keeping a Changelog](https://keepachangelog.com)
 
+- 1.1.0 - 2025-07-10 ivan.bliskavka
+
+  - Added Intent `confirmationFailurePrompt` and `fulfillmentFailurePrompt`
+  - Automatically allow all aliases to call the codehook lambda
+
 - 1.0.2 - 2025-06-06 ivan.bliskavka
 
   - Python example in readme is redundant. ConstructHub automatically makes the conversion

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![CI/CD Pipeline](https://github.com/cxbuilder/aws-lex/actions/workflows/ci-cd.yml/badge.svg)](https://github.com/cxbuilder/aws-lex/actions/workflows/ci-cd.yml)
 [![npm version](https://badge.fury.io/js/@cxbuilder%2Faws-lex.svg)](https://badge.fury.io/js/@cxbuilder%2Faws-lex)
 [![PyPI version](https://badge.fury.io/py/cxbuilder-aws-lex.svg)](https://badge.fury.io/py/cxbuilder-aws-lex)
+[![View on Construct Hub](https://constructs.dev/badge?package=%40cxbuilder%2Faws-lex)](https://constructs.dev/packages/@cxbuilder/aws-lex)
 
 ## Overview
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cxbuilder/aws-lex",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "license": "MIT",
   "description": "Higher-level (L2) constructs for AWS LexV2 bot creation using the AWS CDK",
   "author": {

--- a/src/Bot.ts
+++ b/src/Bot.ts
@@ -118,7 +118,7 @@ export class Bot extends Construct {
     });
 
     // Allow bot alias to invoke function(s)
-    props.locales.forEach((l) => l.addPermission(this.cfnBotAlias.attrArn));
+    props.locales.forEach((l) => l.addPermission(this, this.cfnBot.ref));
   }
 
   private botAliasLocaleSettings(): CfnBotAlias.BotAliasLocaleSettingsItemProperty[] {

--- a/src/Locale.ts
+++ b/src/Locale.ts
@@ -3,6 +3,8 @@ import { CfnBot } from 'aws-cdk-lib/aws-lex';
 import { ServicePrincipal } from 'aws-cdk-lib/aws-iam';
 import { Intent } from './Intent';
 import { SlotType } from './SlotType';
+import { Stack } from 'aws-cdk-lib';
+import { Construct } from 'constructs';
 
 export declare type VoiceEngine =
   | 'generative'
@@ -108,11 +110,15 @@ export class Locale {
     };
   }
 
-  public addPermission(botAliasArn: string): void {
+  /**
+   * Allows all bot aliases to invoke the code hook lambda.
+   */
+  public addPermission(scope: Construct, botId: string): void {
+    const { region, account } = Stack.of(scope);
     this.codeHook?.fn.addPermission(`lex-lambda-invoke-${this.localeId}`, {
       principal: new ServicePrincipal('lexv2.amazonaws.com'),
       action: 'lambda:InvokeFunction',
-      sourceArn: botAliasArn,
+      sourceArn: `arn:aws:lex:${region}:${account}:bot-alias/${botId}/*`,
     });
   }
 }

--- a/test/Intent.test.ts
+++ b/test/Intent.test.ts
@@ -1,0 +1,147 @@
+import { Intent } from '../src/Intent';
+
+describe('Intent', () => {
+  test('should handle utterances with diacritics', () => {
+    const intent = new Intent({
+      name: 'OrderPizza',
+      utterances: ['Quiero una pizza', 'Deseo pedir comida', 'Quiero café']
+    });
+
+    const cdkProps = intent.toCdk(false, false);
+    
+    expect(cdkProps.sampleUtterances).toEqual([
+      { utterance: 'Quiero una pizza' },
+      { utterance: 'Deseo pedir comida' },
+      { utterance: 'Quiero café' }
+    ]);
+  });
+
+  test('should handle confirmation prompt with diacritics', () => {
+    const intent = new Intent({
+      name: 'OrderPizza',
+      utterances: ['Order pizza'],
+      confirmationPrompt: '¿Estás seguro que quieres pedir café?'
+    });
+
+    const cdkProps = intent.toCdk(false, false);
+    
+    const confirmationSetting = cdkProps.intentConfirmationSetting as any;
+    expect(confirmationSetting?.promptSpecification.messageGroupsList[0].message.plainTextMessage?.value)
+      .toBe('¿Estás seguro que quieres pedir café?');
+  });
+
+  test('should handle fulfillment prompt with diacritics', () => {
+    const intent = new Intent({
+      name: 'OrderPizza',
+      utterances: ['Order pizza'],
+      fulfillmentPrompt: 'Tu pedido de café está listo'
+    });
+
+    const cdkProps = intent.toCdk(false, true);
+    
+    const fulfillmentHook = cdkProps.fulfillmentCodeHook as any;
+    expect(fulfillmentHook?.postFulfillmentStatusSpecification?.successResponse?.messageGroupsList[0].message.plainTextMessage?.value)
+      .toBe('Tu pedido de café está listo');
+  });
+
+  test('should handle custom fulfillment failure prompt with diacritics', () => {
+    const intent = new Intent({
+      name: 'OrderPizza',
+      utterances: ['Order pizza'],
+      fulfillmentPrompt: 'Your order is ready',
+      fulfillmentFailurePrompt: 'Lo siento, no pude procesar tu pedido de café'
+    });
+
+    const cdkProps = intent.toCdk(false, true);
+    
+    const fulfillmentHook = cdkProps.fulfillmentCodeHook as any;
+    expect(fulfillmentHook?.postFulfillmentStatusSpecification?.failureResponse?.messageGroupsList[0].message.plainTextMessage?.value)
+      .toBe('Lo siento, no pude procesar tu pedido de café');
+  });
+
+  test('should handle custom confirmation failure prompt with diacritics', () => {
+    const intent = new Intent({
+      name: 'OrderPizza',
+      utterances: ['Order pizza'],
+      confirmationPrompt: 'Are you sure?',
+      confirmationFailurePrompt: 'Está bien, no procederé con tu pedido'
+    });
+
+    const cdkProps = intent.toCdk(false, false);
+    
+    const confirmationSetting = cdkProps.intentConfirmationSetting as any;
+    expect(confirmationSetting?.declinationResponse?.messageGroupsList[0].message.plainTextMessage?.value)
+      .toBe('Está bien, no procederé con tu pedido');
+  });
+
+  test('should conditionally include confirmation responses', () => {
+    // Only confirmation prompt
+    const intent1 = new Intent({
+      name: 'OrderPizza',
+      utterances: ['Order pizza'],
+      confirmationPrompt: 'Are you sure?'
+    });
+
+    const cdkProps1 = intent1.toCdk(false, false);
+    const confirmationSetting1 = cdkProps1.intentConfirmationSetting as any;
+    expect(confirmationSetting1?.promptSpecification).toBeDefined();
+    expect(confirmationSetting1?.declinationResponse).toBeUndefined();
+
+    // Only confirmation failure prompt
+    const intent2 = new Intent({
+      name: 'OrderPizza',
+      utterances: ['Order pizza'],
+      confirmationFailurePrompt: 'Cancelled'
+    });
+
+    const cdkProps2 = intent2.toCdk(false, false);
+    const confirmationSetting2 = cdkProps2.intentConfirmationSetting as any;
+    expect(confirmationSetting2?.promptSpecification).toBeUndefined();
+    expect(confirmationSetting2?.declinationResponse).toBeDefined();
+
+    // No confirmation prompts
+    const intent3 = new Intent({
+      name: 'OrderPizza',
+      utterances: ['Order pizza']
+    });
+
+    const cdkProps3 = intent3.toCdk(false, false);
+    expect(cdkProps3.intentConfirmationSetting).toBeUndefined();
+  });
+
+  test('should conditionally include fulfillment responses', () => {
+    // Only fulfillment prompt
+    const intent1 = new Intent({
+      name: 'OrderPizza',
+      utterances: ['Order pizza'],
+      fulfillmentPrompt: 'Your order is ready'
+    });
+
+    const cdkProps1 = intent1.toCdk(false, true);
+    const fulfillmentHook1 = cdkProps1.fulfillmentCodeHook as any;
+    expect(fulfillmentHook1?.postFulfillmentStatusSpecification?.successResponse).toBeDefined();
+    expect(fulfillmentHook1?.postFulfillmentStatusSpecification?.failureResponse).toBeUndefined();
+
+    // Only fulfillment failure prompt
+    const intent2 = new Intent({
+      name: 'OrderPizza',
+      utterances: ['Order pizza'],
+      fulfillmentFailurePrompt: 'Something went wrong'
+    });
+
+    const cdkProps2 = intent2.toCdk(false, true);
+    const fulfillmentHook2 = cdkProps2.fulfillmentCodeHook as any;
+    expect(fulfillmentHook2?.postFulfillmentStatusSpecification?.successResponse).toBeUndefined();
+    expect(fulfillmentHook2?.postFulfillmentStatusSpecification?.failureResponse).toBeDefined();
+
+    // No fulfillment prompts
+    const intent3 = new Intent({
+      name: 'OrderPizza',
+      utterances: ['Order pizza']
+    });
+
+    const cdkProps3 = intent3.toCdk(false, true);
+    const fulfillmentHook3 = cdkProps3.fulfillmentCodeHook as any;
+    expect(fulfillmentHook3?.postFulfillmentStatusSpecification).toBeUndefined();
+  });
+});

--- a/test/__snapshots__/AddressChangeBot.test.ts.snap
+++ b/test/__snapshots__/AddressChangeBot.test.ts.snap
@@ -436,9 +436,23 @@ exports[`AddressChangeBot matches snapshot 1`] = `
         },
         "Principal": "lexv2.amazonaws.com",
         "SourceArn": {
-          "Fn::GetAtt": [
-            "AddressChangeBotAlias4B603C78",
-            "Arn",
+          "Fn::Join": [
+            "",
+            [
+              "arn:aws:lex:",
+              {
+                "Ref": "AWS::Region",
+              },
+              ":",
+              {
+                "Ref": "AWS::AccountId",
+              },
+              ":bot-alias/",
+              {
+                "Ref": "AddressChangeBotE5BEDD7F",
+              },
+              "/*",
+            ],
           ],
         },
       },


### PR DESCRIPTION
- 1.1.0 - 2025-07-10 ivan.bliskavka

  - Added Intent `confirmationFailurePrompt` and `fulfillmentFailurePrompt`
  - Automatically allow all aliases to call the codehook lambda